### PR TITLE
Refactor cam control

### DIFF
--- a/nin/dasBoot/CameraController.js
+++ b/nin/dasBoot/CameraController.js
@@ -1,6 +1,9 @@
 function CameraController(layer_id) {
   console.log('started CC', layer_id);
   if (layer_id in CameraController.layers) {
+    if (!CameraController.layers[layer_id].loaded && Object.keys(CameraController.paths).length > 0) {
+      this.parseCameraPath(CameraController.paths);
+    }
     return CameraController.layers[layer_id];
   }
   CameraController.layers[layer_id] = this;
@@ -11,15 +14,16 @@ function CameraController(layer_id) {
   this.rotVector = new THREE.Vector3(0, 0, -1);
   this.pause = false;
 
-  if (CameraController.paths.length > 0) {
+  if (Object.keys(CameraController.paths).length > 0) {
     this.parseCameraPath(CameraController.paths);
   }
-};
+}
 
 CameraController.layers = {};
-CameraController.paths = [];
+CameraController.paths = {};
 
 CameraController.prototype.parseCameraPath = function(camera_paths) {
+  this.loaded = true;
   var raw_path = camera_paths[this.layer_id];
   if (!raw_path) {
     console.warn("No camera path for layer %d", this.layer_id);

--- a/nin/dasBoot/PathController.js
+++ b/nin/dasBoot/PathController.js
@@ -17,20 +17,56 @@ PathController.prototype.parse3Dkeyframes = function(keyframes) {
       endFrame: keyframes[i].endFrame,
       easing: keyframes[i].easing
     };
-    if (this_pos.type == "spline") {
-      var points = [];
-      for (var j=0; j<keyframes[i].points.length; j++) {
-        var point = keyframes[i].points[j];
-        points[j] = new THREE.Vector3(point[0], point[1], point[2]);
+    if (this_pos.type == 'circle') {
+      this_pos.radius = keyframes[i].radius;
+      this_pos.center = new THREE.Vector3(
+        keyframes[i].center[0], keyframes[i].center[1], keyframes[i].center[2]
+      );
+      if (keyframes[i].up) {
+        var up = new THREE.Vector3(
+          keyframes[i].up[0], keyframes[i].up[1], keyframes[i].up[2]
+        );
+        this_pos.angle = new THREE.Vector3(0, 1, 0).angleTo(up);
+        this_pos.rotator = new THREE.Vector3(0, 1, 0).cross(up).normalize();
+      } else {
+        this_pos.angle = 0;
+        this_pos.rotator = new THREE.Vector3(0, 1, 0);
       }
-      this_pos.points = new THREE.SplineCurve3(points);
-    } else if (this_pos.type == "point") {
-      var point = new THREE.Vector3(
-          keyframes[i].point[0],
-          keyframes[i].point[1],
-          keyframes[i].point[2]
-          );
-      this_pos.point = point;
+    } else if (keyframes[i].point || keyframes[i].points) {
+      var raw_points = keyframes[i].point || keyframes[i].points;
+      if (raw_points.length == 1) {
+        this_pos.type = 'point';
+        var point = new THREE.Vector3(
+            raw_points[0][0],
+            raw_points[0][1],
+            raw_points[0][2]
+            );
+        this_pos.point = point;
+      } else if (typeof raw_points[0] === "number" && raw_points.length == 3) {
+        this_pos.type = 'point';
+        var point = new THREE.Vector3(
+            raw_points[0],
+            raw_points[1],
+            raw_points[2]
+            );
+        this_pos.point = point;
+      } else if (raw_points.length == 2) {
+        this_pos.type = 'linear';
+        this_pos.from = new THREE.Vector3(
+          raw_points[0][0], raw_points[0][1], raw_points[0][2]
+        );
+        this_pos.to = new THREE.Vector3(
+          raw_points[1][0], raw_points[1][1], raw_points[1][2]
+        );
+      } else if (raw_points.length > 2) {
+        this_pos.type = 'spline';
+        var points = [];
+        for (var j=0; j<raw_points.length; j++) {
+          var point = raw_points[j];
+          points[j] = new THREE.Vector3(point[0], point[1], point[2]);
+        }
+        this_pos.points = new THREE.SplineCurve3(points);
+      }
     }
     parsed[i] = this_pos;
   }
@@ -46,11 +82,21 @@ PathController.prototype.parseKeyframes = function(keyframes) {
       endFrame: keyframes[i].endFrame,
       easing: keyframes[i].easing
     };
-    if (current.type == "transition") {
-      current.from = keyframes[i].from;
-      current.to = keyframes[i].to;
-    } else if (current.type == "fixed") {
-      current.value = keyframes[i].value;
+    var raw_points = keyframes[i].value || keyframes[i].point || keyframes[i].points;
+    if (raw_points) {
+      if (typeof raw_points === "number") {
+        current.type = 'value';
+        current.value = raw_points;
+      } else if (raw_points.length == 1) {
+        current.type = 'value';
+        current.value = raw_points[0];
+      } else if (raw_points.length == 2) {
+        current.type = 'linear';
+        current.from = keyframes[i].from;
+        current.to = keyframes[i].to;
+      } else if (raw_points.length > 2) {
+        console.warn("A maximum two points is currently supported");
+      }
     }
     parsed[i] = current;
   }
@@ -59,30 +105,53 @@ PathController.prototype.parseKeyframes = function(keyframes) {
 
 PathController.prototype.get3Dpoint = function(frame) {
   var current = this.getCurrentPath(frame);
+  var duration = current.endFrame - current.startFrame;
+  var t = (frame - current.startFrame) / duration;
+  if (current.easing == "smoothstep") {
+    t = smoothstep(0, 1, t);
+  } else if (current.easing == "easeIn") {
+    t = easeIn(0, 1, t);
+  } else if (current.easing == "easeOut") {
+    t = easeOut(0, 1, t);
+  }
 
-  if (current.type == "spline") {
+  if (current.type == 'spline') {
     if (frame > current.endFrame) {
       return current.points.points[current.points.points.length-1];
     }
-    var spline_duration = current.endFrame - current.startFrame;
-    var t = (frame - current.startFrame) / spline_duration;
-    var s_t = t;
-    if (current.easing == "smoothstep") {
-      s_t = smoothstep(0, 1, t);
-    } else if (current.easing == "easeIn") {
-      s_t = easeIn(0, 1, t);
-    } else if (current.easing == "easeOut") {
-      s_t = easeOut(0, 1, t);
+    return current.points.getPointAt(t);
+
+  } else if (current.type == 'linear') {
+    if (frame > current.endFrame) {
+      return current.to;
     }
-    return current.points.getPointAt(s_t);
+    return new THREE.Vector3(
+      lerp(current.from.x, current.to.x, t),
+      lerp(current.from.y, current.to.y, t),
+      lerp(current.from.z, current.to.z, t)
+    );
+
+  } else if (current.type == 'point') {
+    return current.point;
+  } else if (current.type == 'circle') {
+    if (frame > current.endFrame) {
+      t = 0;
+    }
+    var point = new THREE.Vector3(
+      Math.sin(t * Math.PI * 2) * current.radius,
+      0,
+      Math.cos(t * Math.PI * 2) * current.radius
+    );
+    point.applyAxisAngle(current.rotator, current.angle);
+    point.add(current.center);
+    return point;
   }
-  return current.point;
 };
 
 PathController.prototype.getPoint = function(frame) {
   var current = this.getCurrentPath(frame);
 
-  if (current.type == "transition") {
+  if (current.type == 'linear') {
     if (frame > current.endFrame) {
       return current.to;
     }
@@ -96,8 +165,9 @@ PathController.prototype.getPoint = function(frame) {
       return easeIn(current.from, current.to, t);
     }
     return lerp(current.from, current.to, t);
+  } else if (current.type == 'value') {
+    return current.value;
   }
-  return current.value;
 };
 
 PathController.prototype.getCurrentPath = function(frame) {

--- a/nin/dasBoot/PathController.js
+++ b/nin/dasBoot/PathController.js
@@ -1,0 +1,122 @@
+function PathController(raw_path, path_type) {
+  this.path_type = path_type || '3D';
+
+  if (this.path_type == '3D') {
+    this.path = this.parse3Dkeyframes(raw_path);
+  } else if (this.path_type == '1D') {
+    this.path = this.parseKeyframes(raw_path);
+  }
+}
+
+PathController.prototype.parse3Dkeyframes = function(keyframes) {
+  var parsed = [];
+  for (var i=0; i<keyframes.length; i++) {
+    var this_pos = {
+      type: keyframes[i].type,
+      startFrame: keyframes[i].startFrame,
+      endFrame: keyframes[i].endFrame,
+      easing: keyframes[i].easing
+    };
+    if (this_pos.type == "spline") {
+      var points = [];
+      for (var j=0; j<keyframes[i].points.length; j++) {
+        var point = keyframes[i].points[j];
+        points[j] = new THREE.Vector3(point[0], point[1], point[2]);
+      }
+      this_pos.points = new THREE.SplineCurve3(points);
+    } else if (this_pos.type == "point") {
+      var point = new THREE.Vector3(
+          keyframes[i].point[0],
+          keyframes[i].point[1],
+          keyframes[i].point[2]
+          );
+      this_pos.point = point;
+    }
+    parsed[i] = this_pos;
+  }
+  return parsed;
+};
+
+PathController.prototype.parseKeyframes = function(keyframes) {
+  var parsed = [];
+  for (var i=0; i < keyframes.length; i++) {
+    var current = {
+      type: keyframes[i].type,
+      startFrame: keyframes[i].startFrame,
+      endFrame: keyframes[i].endFrame,
+      easing: keyframes[i].easing
+    };
+    if (current.type == "transition") {
+      current.from = keyframes[i].from;
+      current.to = keyframes[i].to;
+    } else if (current.type == "fixed") {
+      current.value = keyframes[i].value;
+    }
+    parsed[i] = current;
+  }
+  return parsed;
+};
+
+PathController.prototype.get3Dpoint = function(frame) {
+  var current = this.getCurrentPath(frame);
+
+  if (current.type == "spline") {
+    if (frame > current.endFrame) {
+      return current.points.points[current.points.points.length-1];
+    }
+    var spline_duration = current.endFrame - current.startFrame;
+    var t = (frame - current.startFrame) / spline_duration;
+    var s_t = t;
+    if (current.easing == "smoothstep") {
+      s_t = smoothstep(0, 1, t);
+    } else if (current.easing == "easeIn") {
+      s_t = easeIn(0, 1, t);
+    } else if (current.easing == "easeOut") {
+      s_t = easeOut(0, 1, t);
+    }
+    return current.points.getPointAt(s_t);
+  }
+  return current.point;
+};
+
+PathController.prototype.getPoint = function(frame) {
+  var current = this.getCurrentPath(frame);
+
+  if (current.type == "transition") {
+    if (frame > current.endFrame) {
+      return current.to;
+    }
+    var duration = current.endFrame - current.startFrame;
+    var t = (frame - current.startFrame) / duration;
+    if (current.easing == "smoothstep") {
+      return smoothstep(current.from, current.to, t);
+    } else if (current.easing == "easeOut") {
+      return easeOut(current.from, current.to, t);
+    } else if (current.easing == "easeIn") {
+      return easeIn(current.from, current.to, t);
+    }
+    return lerp(current.from, current.to, t);
+  }
+  return current.value;
+};
+
+PathController.prototype.getCurrentPath = function(frame) {
+  var current;
+  for (var i=0; i<this.path.length; i++) {
+    if (frame >= this.path[i].startFrame && frame <= this.path[i].endFrame) {
+      current = this.path[i];
+      break;
+    }
+  }
+  if (current === undefined) {
+    for (var i=0; i < this.path.length; i++) {
+      if (frame > this.path[i].startFrame) {
+        current = this.path[i];
+      }
+    }
+    if (current === undefined) {
+      current = this.path[0];
+    }
+  }
+  return current;
+};

--- a/nin/dasBoot/bootstrap.js
+++ b/nin/dasBoot/bootstrap.js
@@ -43,11 +43,12 @@ window['bootstrap'] = function(options) {
     }
     demo.lm.jumpToFrame(0);
   }
+
   if(options.camerapaths) {
     CameraController.paths = options.camerapaths;
     for (var index in CameraController.layers) {
       CameraController.layers[index].parseCameraPath(options.camerapaths);
-    };
+    }
     demo.lm.jumpToFrame(0);
   }
 

--- a/nin/example-project/res/camerapaths.json
+++ b/nin/example-project/res/camerapaths.json
@@ -1,5 +1,5 @@
-[
-    {
+{
+    "BlankLayer": {
         "position": [
         {
             "type": "spline",
@@ -23,31 +23,7 @@
         "roll": [],
         "fov": []
     },
-    {
-        "position": [
-        {
-            "type": "spline",
-            "startFrame": 0,
-            "endFrame": 390,
-            "points": [
-                [0, 0, 200],
-                [0, 200, 100],
-                [0, 200, 150]
-            ]
-        }
-        ],
-        "lookAt": [
-        {
-            "type": "point",
-            "startFrame": 0,
-            "endFrame": 390,
-            "point": [0, 0, 0]
-        }
-        ],
-        "roll": [],
-        "fov": []
-    },
-    {
+    "MountainLayer": {
         "position": [
         {
             "type": "spline",
@@ -154,4 +130,4 @@
         "roll": [],
         "fov": []
     }
-]
+}

--- a/nin/example-project/src/BlankLayer.js
+++ b/nin/example-project/src/BlankLayer.js
@@ -5,7 +5,7 @@ function BlankLayer(layer) {
   this.offset = layer.config.offset;
   this.scene = new THREE.Scene();
 
-  this.cameraController = new CameraController(layer.position);
+  this.cameraController = new CameraController(layer.type);
   this.camera = this.cameraController.camera;
   this.cube = new THREE.Mesh(new THREE.BoxGeometry(50, 5, 5),
                              new THREE.ShaderMaterial(SHADERS.example));

--- a/nin/example-project/src/MountainLayer.js
+++ b/nin/example-project/src/MountainLayer.js
@@ -9,7 +9,7 @@ function MountainLayer(layer) {
   /* do loady stuff here */
 
   this.scene = new THREE.Scene();
-  this.cameraController = new CameraController(layer.position);
+  this.cameraController = new CameraController(layer.type);
   this.camera = this.cameraController.camera;
   this.scene.add(this.camera);
 

--- a/nin/frontend/app/scripts/services/camera.js
+++ b/nin/frontend/app/scripts/services/camera.js
@@ -126,7 +126,7 @@ angular.module('nin')
 
         layer = newLayer;
 
-        cc = CameraController.layers[layer.position];
+        cc = CameraController.layers[layer.type];
       }
     };
   });


### PR DESCRIPTION
This changes the semantics of the connection between a camerapath and a layer slightly.
The old format matched camerapaths in camerapaths.json with corresponding layers in layers.json by their index in the list. This made it difficult to actually keep a camerapath connected to the proper
layer.

A full rework of the system (diffent camerapaths in different files or something similar) might be best, but that's too much work to be completed before solskogen 2015.

The old format meant that a camerapath was linked to an instance of the layer, i.e. two different instances of the layer could (and would) have different camerapaths. With the new system, the camerapath is instead linked to the 'type' of the layer, as `camerapaths.json` is no longer a list, but a dictionary where the layer type is the key for each dictionary.
This should make it easier to manage the relation between layers and camerapaths, and I doubt the possibility of using different camerapaths for different instances of the same layer will be missed.