### PR TITLE
Add newline to layers.json file when writing

### DIFF
--- a/nin/backend/socket.js
+++ b/nin/backend/socket.js
@@ -65,7 +65,7 @@ function socket(projectPath) {
         fs.readFile(projectPath + '/res/layers.json', function (err, data) {
           var layers = JSON.parse(data);
           layers[event.id][event.field] = event.value;
-          fs.writeFile(projectPath + '/res/layers.json', JSON.stringify(layers, null, '  '), function (err) {
+          fs.writeFile(projectPath + '/res/layers.json', JSON.stringify(layers, null, '  ') + '\n', function (err) {
 
           })
         })


### PR DESCRIPTION
The layers.json file didn't have the correct newline on the end of the
file when it was edited from nin.