### PR TITLE
Lock crc dependency version to 2.0.0

### DIFF
--- a/nin/backend/package.json
+++ b/nin/backend/package.json
@@ -5,7 +5,7 @@
   {
     "commander": "2.2.x",
     "walk":  "2.2.x",
-    "crc": "2.x",
+    "crc": "2.0.0",
     "express": "4.3.x",
     "sockjs": "0.3.x",
     "chokidar": "0.8.x",


### PR DESCRIPTION
Newer versions break png.html-compression.