### PR TITLE
Normalize paths and use node modules for find and cat operations

### DIFF
--- a/nin/backend/package.json
+++ b/nin/backend/package.json
@@ -9,6 +9,9 @@
     "express": "4.3.x",
     "sockjs": "0.3.x",
     "chokidar": "0.8.x",
-    "jsonfile": "1.1.x"
+    "jsonfile": "1.1.x",
+    "mkdirp": "0.5.x",
+    "readdir": "0.0.x",
+    "concat-files": "0.1.x"
   }
 }


### PR DESCRIPTION
`nin run` should now work as expected on Windows. I haven't tested it on Mac and Linux.