### PR TITLE
Remove dbl scroll

### DIFF
--- a/nin/frontend/app/styles/main.css
+++ b/nin/frontend/app/styles/main.css
@@ -140,7 +140,7 @@ main-window, main-window > div {
 .layer-bar {
     height: 30px;
     background: #888;
-    display: inline-block;
+    display: block;
     width: auto;
 }
 

--- a/nin/frontend/app/styles/main.css
+++ b/nin/frontend/app/styles/main.css
@@ -126,7 +126,7 @@ main-window, main-window > div {
 }
 
 .layers-bar-container {
-    overflow: scroll;
+    overflow-x: scroll;
     width: calc(100% - 150px);
     height: 100%;
     float: left;


### PR DESCRIPTION
I think I recall testing display: block before, but I don't remember why I decided not to push it.

Anyway, it seems to fix issues I see with layers ending up in the wrong spot in the layers panel

**Bad:**
<img width="915" alt="screenshot 2015-07-09 17 59 43" src="https://cloud.githubusercontent.com/assets/1413267/8600082/4e4507e4-2664-11e5-86f1-f61730dcd3e2.png">

**Good:**
<img width="911" alt="screenshot 2015-07-09 17 59 17" src="https://cloud.githubusercontent.com/assets/1413267/8600081/4e2040bc-2664-11e5-8d90-f0e8fdd073e8.png">